### PR TITLE
Ajout du PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Description
+<!-- Résumé des changements. -->
+
+### :rocket: Nouveauté
+
+### :tada: Quality of life
+
+### :bug: Bugfix
+
+### :hammer_and_wrench: Refactoring
+
+## Dépendance issues/pull request
+<!-- * #{Numéro issue } -->
+
+## Checklist
+
+- [ ] Titre
+- [ ] Label
+- [ ] Catégorie


### PR DESCRIPTION
Ajout du template utilisé pour les PR sur [Yatga](https://github.com/TableauBits/Yatga) et [Kalimba](https://github.com/TableauBits/Kalimba).

Est-ce qu'on veut aussi avoir des labels personnalisés ?