### PR TITLE
Classer les chansons par ordre croissant/décroissant en fonction d'un champ 

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -9,6 +9,8 @@ import { MatTableModule } from '@angular/material/table'
 import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
+import { MatSortModule } from '@angular/material/sort';
+
 @NgModule({
   declarations: [
     AppComponent,
@@ -21,7 +23,8 @@ import { MatInputModule } from '@angular/material/input';
     MatTableModule,
     MatPaginatorModule,
     MatFormFieldModule,
-    MatInputModule
+    MatInputModule,
+    MatSortModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/components/table-viewer/table-viewer.component.html
+++ b/src/app/components/table-viewer/table-viewer.component.html
@@ -21,7 +21,7 @@
                 </ng-container>
 
                 <ng-container matColumnDef="platform">
-                        <th mat-header-cell *matHeaderCellDef mat-sort-header> Platforme </th>
+                        <th mat-header-cell *matHeaderCellDef> Platforme </th>
                         <td mat-cell *matCellDef="let row"> {{row.platform}} </td>
                 </ng-container>
 
@@ -31,7 +31,7 @@
                 </ng-container>
 
                 <ng-container matColumnDef="url">
-                        <th mat-header-cell *matHeaderCellDef mat-sort-header> URL </th>
+                        <th mat-header-cell *matHeaderCellDef> URL </th>
                         <td mat-cell *matCellDef="let row"> {{row.url}} </td>
                 </ng-container>
 

--- a/src/app/components/table-viewer/table-viewer.component.ts
+++ b/src/app/components/table-viewer/table-viewer.component.ts
@@ -24,12 +24,12 @@ export class TableViewerComponent implements AfterViewInit {
     this.dataSource = new MatTableDataSource(dataManager.songs);
   }
 
-  ngAfterViewInit() {
+  ngAfterViewInit(): void {
     this.dataSource.paginator = this.paginator;
     this.dataSource.sort = this.sort;
   }
 
-  applyFilter(event: Event) {
+  applyFilter(event: Event): void {
     const filterValue = (event.target as HTMLInputElement).value;
     this.dataSource.filter = filterValue.trim().toLowerCase();
 


### PR DESCRIPTION
## Description
<!-- Résumé des changements. -->

### :tada: Quality of life
* Les colonnes peuvent être ordonnées par ordre croissant / décroissant. Cela englobe tous les champs d'une chanson sauf "Platforme" et "URL"

### :hammer_and_wrench: Refactoring
* Ajout du module `MatSortModule`

## Dépendance issues/pull request
<!-- * #{Numéro issue } -->
* Attendre #23 
* Close #11 

## Checklist

À être vérifié par les reviewers: 
- [x] La PR a un bon titre
- [x] Les labels sont bien attribués
- [x] Les champs de la PR sont correctement remplis