### PR TITLE
Conservation de l'ordre des colonnes dans le `localStorage`

### DIFF
--- a/src/app/components/table-viewer/table-viewer.component.ts
+++ b/src/app/components/table-viewer/table-viewer.component.ts
@@ -8,8 +8,6 @@ import { LocalStorageKey } from 'src/app/constants/local-storage';
 import { DataManagerService, DataSong } from 'src/app/services/data-manager.service';
 import { LocalStorageService } from 'src/app/services/local-storage.service';
 
-const COLUMNS_ORDER = ["id", "title", "author", "user", "cstName", "date", "platform", "url"];
-
 @Component({
   selector: 'app-table-viewer',
   templateUrl: './table-viewer.component.html',
@@ -27,7 +25,7 @@ export class TableViewerComponent implements AfterViewInit {
     public dataManager: DataManagerService,
     public localStorage: LocalStorageService
   ) {
-    this.displayedColumns = COLUMNS_ORDER;
+    this.displayedColumns = JSON.parse(this.localStorage.get(LocalStorageKey.TABLE_COLUMN_ORDER))
 
     // Assign the data to the data source for the table to render
     this.dataSource = new MatTableDataSource(dataManager.songs);
@@ -68,5 +66,6 @@ export class TableViewerComponent implements AfterViewInit {
 
   drop(event: CdkDragDrop<string[]>) {
     moveItemInArray(this.displayedColumns, event.previousIndex, event.currentIndex);
+    this.localStorage.set(LocalStorageKey.TABLE_COLUMN_ORDER, JSON.stringify(this.displayedColumns));
   }
 }

--- a/src/app/constants/local-storage.ts
+++ b/src/app/constants/local-storage.ts
@@ -1,3 +1,22 @@
+const DEFAULT_COLUMNS_ORDER = ["id", "title", "author", "user", "cstName", "date", "platform", "url"];
+
 export enum LocalStorageKey {
+  TABLE_COLUMN_ORDER = "mellotron.setting.tableColumnOrder",
   TABLE_PAGE_SIZE_KEY = "mellotron.setting.tablePageSize",
 }
+
+type LocalStorageItem = {
+  key: LocalStorageKey
+  value: string
+}
+
+export const INITIAL_LOCAL_STORAGE: LocalStorageItem[] = [
+  {
+    key: LocalStorageKey.TABLE_COLUMN_ORDER,
+    value: JSON.stringify(DEFAULT_COLUMNS_ORDER),
+  },
+  {
+    key: LocalStorageKey.TABLE_PAGE_SIZE_KEY,
+    value: "5",
+  },
+]

--- a/src/app/services/local-storage.service.ts
+++ b/src/app/services/local-storage.service.ts
@@ -1,17 +1,5 @@
 import { Injectable } from '@angular/core';
-import { LocalStorageKey } from '../constants/local-storage';
-
-type LocalStorageItem = {
-  key: LocalStorageKey
-  value: string
-}
-
-const INITIAL_LOCAL_STORAGE: LocalStorageItem[] = [
-  {
-    key: LocalStorageKey.TABLE_PAGE_SIZE_KEY,
-    value: "5",
-  }
-]
+import { INITIAL_LOCAL_STORAGE, LocalStorageKey } from '../constants/local-storage';
 
 @Injectable({
   providedIn: 'root'


### PR DESCRIPTION
## Description
<!-- Résumé des changements. -->

### :tada: Quality of life
* L'application se rappelle désormais de l'ordre des columns d'une ouverture à l'autre.

### :hammer_and_wrench: Refactoring
* Regroupement des constantes / types pour l'initialisation du local storage.

## Dépendance issues/pull request
<!-- * #{Numéro issue } -->
* Relié à #28

## Checklist

À être vérifié par les reviewers: 
- [x] La PR a un bon titre
- [x] Les labels sont bien attribués
- [x] Les champs de la PR sont correctement remplis