### PR TITLE
Possible de sélectionner les colonnes à afficher

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,6 +3,7 @@ import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { AppRoutingModule } from './app-routing.module';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { ReactiveFormsModule } from '@angular/forms';
 
 // Angular Material Module
 import { MatTableModule } from '@angular/material/table';
@@ -11,6 +12,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSortModule } from '@angular/material/sort';
+import { MatSelectModule } from '@angular/material/select';
 
 // Component
 import { AppComponent } from './app.component';
@@ -25,12 +27,14 @@ import { TableViewerComponent } from './components/table-viewer/table-viewer.com
     BrowserModule,
     AppRoutingModule,
     BrowserAnimationsModule,
+    ReactiveFormsModule,
     MatTableModule,
     MatPaginatorModule,
     MatFormFieldModule,
     MatInputModule,
     MatIconModule,
     MatSortModule,
+    MatSelectModule,
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/components/table-viewer/table-viewer.component.html
+++ b/src/app/components/table-viewer/table-viewer.component.html
@@ -9,37 +9,44 @@
                 </mat-option>
         </mat-select>
 </mat-form-field>
+<span class="warning-text" *ngIf="!canDrag()">
+        L'ordre des colonnes ne peut pas être modifié dans cette configuration
+</span>
 <div class="mat-elevation-z8">
         <table mat-table [dataSource]="dataSource" matSort cdkDropList cdkDropListOrientation="horizontal"
                 (cdkDropListDropped)="drop($any($event))">
 
                 <ng-container matColumnDef="id">
-                        <th mat-header-cell cdkDrag *matHeaderCellDef mat-sort-header> ID </th>
+                        <th mat-header-cell cdkDrag [cdkDragDisabled]="!canDrag()" *matHeaderCellDef mat-sort-header> ID
+                        </th>
                         <td mat-cell *matCellDef="let row"> {{row.id}} </td>
                 </ng-container>
 
                 <ng-container matColumnDef="title">
-                        <th mat-header-cell cdkDrag *matHeaderCellDef mat-sort-header> Titre </th>
+                        <th mat-header-cell cdkDrag [cdkDragDisabled]="!canDrag()" *matHeaderCellDef mat-sort-header>
+                                Titre </th>
                         <td mat-cell *matCellDef="let row"> {{row.title}} </td>
                 </ng-container>
 
                 <ng-container matColumnDef="author">
-                        <th mat-header-cell cdkDrag *matHeaderCellDef mat-sort-header> Auteur </th>
+                        <th mat-header-cell cdkDrag [cdkDragDisabled]="!canDrag()" *matHeaderCellDef mat-sort-header>
+                                Auteur </th>
                         <td mat-cell *matCellDef="let row"> {{row.author}} </td>
                 </ng-container>
 
                 <ng-container matColumnDef="platform">
-                        <th mat-header-cell cdkDrag *matHeaderCellDef> Plateforme </th>
+                        <th mat-header-cell cdkDrag [cdkDragDisabled]="!canDrag()" *matHeaderCellDef> Plateforme </th>
                         <td mat-cell *matCellDef="let row"> {{platformToString(row.platform)}} </td>
                 </ng-container>
 
                 <ng-container matColumnDef="cstName">
-                        <th mat-header-cell cdkDrag *matHeaderCellDef mat-sort-header> Constitution </th>
+                        <th mat-header-cell cdkDrag [cdkDragDisabled]="!canDrag()" *matHeaderCellDef mat-sort-header>
+                                Constitution </th>
                         <td mat-cell *matCellDef="let row"> {{row.cstName}} </td>
                 </ng-container>
 
                 <ng-container matColumnDef="url">
-                        <th mat-header-cell cdkDrag *matHeaderCellDef> URL </th>
+                        <th mat-header-cell cdkDrag [cdkDragDisabled]="!canDrag()" *matHeaderCellDef> URL </th>
                         <td mat-cell *matCellDef="let row">
                                 <a href="{{row.url}}" target="_blank">
                                         <mat-icon>play_circle_outline</mat-icon>
@@ -48,12 +55,14 @@
                 </ng-container>
 
                 <ng-container matColumnDef="user">
-                        <th mat-header-cell cdkDrag *matHeaderCellDef mat-sort-header> Utilisateur </th>
+                        <th mat-header-cell cdkDrag [cdkDragDisabled]="!canDrag()" *matHeaderCellDef mat-sort-header>
+                                Utilisateur </th>
                         <td mat-cell *matCellDef="let row"> {{row.user}} </td>
                 </ng-container>
 
                 <ng-container matColumnDef="date">
-                        <th mat-header-cell cdkDrag *matHeaderCellDef mat-sort-header> Date </th>
+                        <th mat-header-cell cdkDrag [cdkDragDisabled]="!canDrag()" *matHeaderCellDef mat-sort-header>
+                                Date </th>
                         <td mat-cell *matCellDef="let row"> {{row.date}} </td>
                 </ng-container>
 

--- a/src/app/components/table-viewer/table-viewer.component.html
+++ b/src/app/components/table-viewer/table-viewer.component.html
@@ -5,7 +5,8 @@
 <mat-form-field appearance="fill">
         <mat-label>Champs</mat-label>
         <mat-select [formControl]="selectedColumns" multiple (selectionChange)="updateSelection()">
-                <mat-option *ngFor="let column of selectedColumnsList" [value]="column">{{column}}</mat-option>
+                <mat-option *ngFor="let column of selectedColumnsList" [value]="column">{{toColumnName(column)}}
+                </mat-option>
         </mat-select>
 </mat-form-field>
 <div class="mat-elevation-z8">

--- a/src/app/components/table-viewer/table-viewer.component.html
+++ b/src/app/components/table-viewer/table-viewer.component.html
@@ -2,7 +2,12 @@
         <mat-label>Recherche</mat-label>
         <input matInput (keyup)="applyFilter($event)" placeholder="Ex. 'Specialist'" #input>
 </mat-form-field>
-
+<mat-form-field appearance="fill">
+        <mat-label>Champs</mat-label>
+        <mat-select [formControl]="selectedColumns" multiple (selectionChange)="updateSelection()">
+                <mat-option *ngFor="let column of selectedColumnsList" [value]="column">{{column}}</mat-option>
+        </mat-select>
+</mat-form-field>
 <div class="mat-elevation-z8">
         <table mat-table [dataSource]="dataSource" matSort>
                 <ng-container matColumnDef="id">

--- a/src/app/components/table-viewer/table-viewer.component.scss
+++ b/src/app/components/table-viewer/table-viewer.component.scss
@@ -7,3 +7,7 @@ mat-form-field {
     margin-left: 5%;
     margin-top: 0.5%;
 }
+
+.warning-text {
+    margin-left: 1%;
+}

--- a/src/app/components/table-viewer/table-viewer.component.scss
+++ b/src/app/components/table-viewer/table-viewer.component.scss
@@ -5,4 +5,5 @@ table {
 
 mat-form-field {
     margin-left: 5%;
+    margin-top: 0.5%;
 }

--- a/src/app/components/table-viewer/table-viewer.component.ts
+++ b/src/app/components/table-viewer/table-viewer.component.ts
@@ -1,4 +1,5 @@
 import { AfterViewInit, Component, ViewChild } from '@angular/core';
+import { FormControl } from '@angular/forms';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
@@ -17,11 +18,19 @@ export class TableViewerComponent implements AfterViewInit {
   displayedColumns: string[];
   dataSource: MatTableDataSource<DataSong>;
 
+  selectedColumns: FormControl;
+  selectedColumnsList: string[];
+
   @ViewChild(MatPaginator) paginator!: MatPaginator;
   @ViewChild(MatSort) sort!: MatSort;
 
   constructor(public dataManager: DataManagerService) {
     this.displayedColumns = COLUMNS_ORDER;
+
+    this.selectedColumnsList = COLUMNS_ORDER;
+    this.selectedColumns = new FormControl('');
+    this.selectedColumns.setValue(this.selectedColumnsList);
+    
 
     // Assign the data to the data source for the table to render
     this.dataSource = new MatTableDataSource(dataManager.songs);
@@ -49,5 +58,16 @@ export class TableViewerComponent implements AfterViewInit {
       default:
         return "Unknown"
     }
+  }
+
+
+  updateSelection(): void {
+    this.displayedColumns = this.selectedColumns.value;
+
+    // this.dataSource.filterPredicate = function(row: DataSong, filter: string): boolean {
+    //   return false;
+    // }
+
+
   }
 }

--- a/src/app/components/table-viewer/table-viewer.component.ts
+++ b/src/app/components/table-viewer/table-viewer.component.ts
@@ -5,7 +5,8 @@ import { MatPaginator, PageEvent } from '@angular/material/paginator';
 import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
 import { SongPlatform } from 'chelys';
-import { DEFAULT_COLUMNS_ORDER, LocalStorageKey } from 'src/app/constants/local-storage';
+import { LocalStorageKey } from 'src/app/constants/local-storage';
+import { COLUMN_NAMES_MAP, DEFAULT_COLUMNS_ORDER, NON_FILTER_KEYS } from 'src/app/constants/table';
 import { DataManagerService, DataSong } from 'src/app/services/data-manager.service';
 import { LocalStorageService } from 'src/app/services/local-storage.service';
 
@@ -38,6 +39,27 @@ export class TableViewerComponent implements AfterViewInit {
 
     // Assign the data to the data source for the table to render
     this.dataSource = new MatTableDataSource(dataManager.songs);
+
+    // From the default implementation of filterPredicate
+    this.dataSource.filterPredicate = (data: DataSong, filter: string): boolean => {
+      // Transform the data into a lowercase string of all property values.
+      const dataStr = Object.keys(data).filter((value) => !NON_FILTER_KEYS.includes(value))
+        .reduce((currentTerm: string, key: string) => {
+          // Use an obscure Unicode character to delimit the words in the concatenated string.
+          // This avoids matches where the values of two columns combined will match the user's query
+          // (e.g. `Flute` and `Stop` will match `Test`). The character is intended to be something
+          // that has a very low chance of being typed in by somebody in a text field. This one in
+          // particular is "White up-pointing triangle with dot" from
+          // https://en.wikipedia.org/wiki/List_of_Unicode_characters
+          return currentTerm + (data as {[key: string]: any})[key] + '◬';
+        }, '')
+        .toLowerCase();
+  
+      // Transform the filter by converting it to lowercase and removing whitespace.
+      const transformedFilter = filter.trim().toLowerCase();
+  
+      return dataStr.indexOf(transformedFilter) != -1;
+    };
   }
 
   ngAfterViewInit() {
@@ -84,6 +106,10 @@ export class TableViewerComponent implements AfterViewInit {
   drop(event: CdkDragDrop<string[]>) {
     moveItemInArray(this.displayedColumns, event.previousIndex, event.currentIndex);
     this.localStorage.set(LocalStorageKey.TABLE_COLUMN_ORDER, JSON.stringify(this.displayedColumns));
+  }
+
+  toColumnName(name: string): string {
+    return COLUMN_NAMES_MAP[name] || "";
   }
 
 }

--- a/src/app/constants/local-storage.ts
+++ b/src/app/constants/local-storage.ts
@@ -2,6 +2,7 @@ import { DEFAULT_COLUMNS_ORDER } from "./table"
 
 export enum LocalStorageKey {
   TABLE_COLUMN_ORDER = "mellotron.setting.tableColumnOrder",
+  TABLE_DISPLAYED_COLUMNS = "mellotron.setting.tableDisplayedColumns",
   TABLE_PAGE_SIZE_KEY = "mellotron.setting.tablePageSize",
 }
 
@@ -13,6 +14,10 @@ type LocalStorageItem = {
 export const INITIAL_LOCAL_STORAGE: LocalStorageItem[] = [
   {
     key: LocalStorageKey.TABLE_COLUMN_ORDER,
+    value: JSON.stringify(DEFAULT_COLUMNS_ORDER),
+  },
+  {
+    key: LocalStorageKey.TABLE_DISPLAYED_COLUMNS,
     value: JSON.stringify(DEFAULT_COLUMNS_ORDER),
   },
   {

--- a/src/app/constants/local-storage.ts
+++ b/src/app/constants/local-storage.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_COLUMNS_ORDER = ["id", "title", "author", "user", "cstName", "date", "platform", "url"];
+import { DEFAULT_COLUMNS_ORDER } from "./table"
 
 export enum LocalStorageKey {
   TABLE_COLUMN_ORDER = "mellotron.setting.tableColumnOrder",

--- a/src/app/constants/table.ts
+++ b/src/app/constants/table.ts
@@ -1,3 +1,5 @@
+import { DataSong } from "../services/data-manager.service";
+
 export const COLUMN_NAMES_MAP: Record<string, string> = {
   "id": "ID",
   "title": "Titre",
@@ -9,7 +11,28 @@ export const COLUMN_NAMES_MAP: Record<string, string> = {
   "url": "URL"
 }
 
-export const DEFAULT_COLUMNS_ORDER = Object.keys(COLUMN_NAMES_MAP) // ["id", "title", "author", "user", "cstName", "date", "platform", "url"];
+export const DEFAULT_COLUMNS_ORDER = Object.keys(COLUMN_NAMES_MAP);
 
 export const NON_FILTER_KEYS = ["platform", "url"]
 
+export function filterPredicateFunction(currentKeys: string[]) {
+  return (data: DataSong, filter: string): boolean => {
+    // Transform the data into a lowercase string of all property values.
+    const dataStr = Object.keys(data).filter((value) => currentKeys.includes(value) && !NON_FILTER_KEYS.includes(value))
+      .reduce((currentTerm: string, key: string) => {
+        // Use an obscure Unicode character to delimit the words in the concatenated string.
+        // This avoids matches where the values of two columns combined will match the user's query
+        // (e.g. `Flute` and `Stop` will match `Test`). The character is intended to be something
+        // that has a very low chance of being typed in by somebody in a text field. This one in
+        // particular is "White up-pointing triangle with dot" from
+        // https://en.wikipedia.org/wiki/List_of_Unicode_characters
+        return currentTerm + (data as {[key: string]: any})[key] + '◬';
+      }, '')
+      .toLowerCase();
+
+    // Transform the filter by converting it to lowercase and removing whitespace.
+    const transformedFilter = filter.trim().toLowerCase();
+
+    return dataStr.indexOf(transformedFilter) != -1;
+  };
+}

--- a/src/app/constants/table.ts
+++ b/src/app/constants/table.ts
@@ -1,0 +1,15 @@
+export const COLUMN_NAMES_MAP: Record<string, string> = {
+  "id": "ID",
+  "title": "Titre",
+  "author": "Auteur",
+  "user": "Utilisateur",
+  "cstName": "Constitution",
+  "date": "Date",
+  "platform": "Plateforme",
+  "url": "URL"
+}
+
+export const DEFAULT_COLUMNS_ORDER = Object.keys(COLUMN_NAMES_MAP) // ["id", "title", "author", "user", "cstName", "date", "platform", "url"];
+
+export const NON_FILTER_KEYS = ["platform", "url"]
+


### PR DESCRIPTION
## Description
<!-- Résumé des changements. -->

Ajout d'une option pour afficher/masquer les colonnes de la table.

### :rocket: Nouveauté
* Ajout d'un sélecteur pour choisir quelles colonnes à afficher ou non.
* Les colonnes affichés sont sauvegardés d'une utilisation à une autre du site via le `localStorage`.
* L'ordre des colonnes ne peut pas être modifié si des colonnes sont masqués.

### :tada: Quality of life
* La recherche par filtre s'applique seulement aux colonnes affichées.
* La recherche ne s'applique plus au champ "Plateforme" et "URL". Ces champs ne font que brouiller le résultat du filtre.

### :hammer_and_wrench: Refactoring
* Ajout du fichier `table.ts` conservant des constantes sur la table (id/nom des colonnes, prédicats de recherche, etc).

## Dépendance issues/pull request
<!-- * #{Numéro issue } -->

* Close #29 

## Checklist

À être vérifié par les reviewers: 
- [ ] La PR a un bon titre
- [ ] Les labels sont bien attribués
- [ ] Les champs de la PR sont correctement remplis