### PR TITLE
Inverse l'ordre de l'ID des chansons

### DIFF
--- a/src/app/services/data-manager.service.ts
+++ b/src/app/services/data-manager.service.ts
@@ -13,9 +13,9 @@ export const EMPTY_DATA_SONG: DataSong = {
   date: ""
 }
 
-function sortConstitutionByDateDSC(c1: DataConstitution, c2: DataConstitution): number {
-  if (c1.date < c2.date) return 1;
-  if (c1.date > c2.date) return -1;
+function sortConstitutionByDateASC(c1: DataConstitution, c2: DataConstitution): number {
+  if (c1.date < c2.date) return -1;
+  if (c1.date > c2.date) return 1;
   return 0;
 }
 
@@ -35,8 +35,8 @@ export class DataManagerService {
   }
 
   private init() {
-    // Sort constitutions by date, the most recent first
-    this.constitutions = this.constitutions.sort(sortConstitutionByDateDSC);
+    // Sort constitutions by date, the most old first
+    this.constitutions = this.constitutions.sort(sortConstitutionByDateASC);
 
     // Song counter (also generate unique id)
     let i = 0;
@@ -53,5 +53,8 @@ export class DataManagerService {
         }
       }));
     })
+
+    // Display most recent songs first
+    this.songs = this.songs.reverse();
   }
 }

--- a/src/app/services/data-manager.service.ts
+++ b/src/app/services/data-manager.service.ts
@@ -35,7 +35,7 @@ export class DataManagerService {
   }
 
   private init() {
-    // Sort constitutions by date, the most old first
+    // Sort constitutions by date, the oldest first
     this.constitutions = this.constitutions.sort(sortConstitutionByDateASC);
 
     // Song counter (also generate unique id)


### PR DESCRIPTION
## Description
<!-- Résumé des changements. -->

Inverse l'ordre de génération de l'ID des chansons. La première chanson de la première constitution devrait avoir l'ID 1 afin de faciliter la recherche d'ID et éviter que ce nombre ne change à chaque nouvel ajout.

### :tada: Quality of life
* Évite de changer tous les ids lors de l'ajout des constitutions plus récentes.

## Checklist

À être vérifié par les reviewers: 
- [ ] La PR a un bon titre
- [ ] Les labels sont bien attribués
- [ ] Les champs de la PR sont correctement remplis