### PR TITLE
Retrait du port 3000 du script `kalimba.js`

### DIFF
--- a/kalimba.js
+++ b/kalimba.js
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import fetch from 'node-fetch'
 
-const USER_INFO_URL = 'https://kalimba.fly.dev:3000/user-info'
+const USER_INFO_URL = 'https://kalimba.fly.dev/user-info'
 const FILE_PATH = 'src/assets/names.json'
  
 console.log('start')


### PR DESCRIPTION
## Description
<!-- Résumé des changements. -->
Retrait du port 3000 de l'URL utilisée pour récupérer les noms des utilisateurs suite aux modifications de déploiement de Kalimba.

### :bug: Bugfix
- Retrait du port 3000 de `kalimba.js`.

## Checklist

À être vérifié par les reviewers: 
- [x] La PR a un bon titre
- [x] Les labels sont bien attribués
- [x] Les champs de la PR sont correctement remplis